### PR TITLE
Option: maxUses & Validator function

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,14 @@ import createPhantomPool from 'phantom-pool'
 const pool = createPhantomPool({
   max: 10, // default
   min: 2, // default
-  // specifies how long a resource can stay idle in pool before being removed
+  // how long a resource can stay idle in pool before being removed
   idleTimeoutMillis: 30000, // default.
+  // maximum number of times an individual resource can be reused before being destroyed; set to 0 to disable
+  maxUses: 50, // default
+  // function to validate an instance prior to use; see https://github.com/coopernurse/node-pool#createpool
+  validator: () => Promise.resolve(true), // defaults to always resolving true
+  // validate resource before borrowing; required for `maxUses and `validator`
+  testOnBorrow: true // default
   // For all opts, see opts at https://github.com/coopernurse/node-pool#createpool
   phantomArgs: [['--ignore-ssl-errors=true', '--disk-cache=true'], {
     logLevel: 'debug',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "phantom-pool",
   "version": "1.0.0",
-  "description": "Resource pool for Node.js PhanomJS",
+  "description": "Resource pool for Node.js PhantomJS",
   "main": "./lib/index.js",
   "directories": {
     "test": "test"

--- a/src/index.js
+++ b/src/index.js
@@ -11,12 +11,14 @@ export default ({
   // specifies how long a resource can stay idle in pool before being removed
   idleTimeoutMillis = 30000,
   phantomArgs = [],
+  validator,
   ...otherConfig
 } = {}) => {
   // TODO: randomly destroy old instances to avoid resource leak?
   const factory = {
     create: () => phantom.create(...phantomArgs),
     destroy: (instance) => instance.exit(),
+    validate: validator,
   }
   const config = {
     max,


### PR DESCRIPTION
Added the ability to specify a `validator` function when constructing a new phantom-pool, leveraging the underlying generic-pool implementation of that functionality. (Also fixed a typo in the package description.)