### PR TITLE
Trimmed down and made compatible with node --harmony

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["blockai"]
-}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": "blockai"
-}

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ node_modules
 # Temporary / data folders
 .tmp
 data/
+package-lock.json
 
 # Build directory
-lib/
 .npmrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-language: node_js
-notifications:
-  email: false
-node_js:
-  - 6

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ node --harmony my_phantom_pool_dependant_app.js
 See [./test](./test) directory for usage examples.
 
 ```javascript
-import createPhantomPool from 'phantom-pool'
+const createPhantomPool = require('phantom-pool');
 
 // Returns a generic-pool instance
 const pool = createPhantomPool({
@@ -78,7 +78,7 @@ const pool = createPhantomPool({
   testOnBorrow: true, // default
   // For all opts, see opts at https://github.com/coopernurse/node-pool#createpool
   phantomArgs: [['--ignore-ssl-errors=true', '--disk-cache=true'], {
-    logLevel: 'debug',
+    logLevel: 'debug'
   }] // arguments passed to phantomjs-node directly, default is `[]`. For all opts, see https://github.com/amir20/phantomjs-node#phantom-object-api
 })
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Requires Node v6+
 
 ## Usage
 
+Currently this package only work if run with the harmony flag:
+```
+node --harmony my_phantom_pool_dependant_app.js
+```
+
 See [./test](./test) directory for usage examples.
 
 ```javascript
@@ -70,11 +75,11 @@ const pool = createPhantomPool({
   // function to validate an instance prior to use; see https://github.com/coopernurse/node-pool#createpool
   validator: () => Promise.resolve(true), // defaults to always resolving true
   // validate resource before borrowing; required for `maxUses and `validator`
-  testOnBorrow: true // default
+  testOnBorrow: true, // default
   // For all opts, see opts at https://github.com/coopernurse/node-pool#createpool
   phantomArgs: [['--ignore-ssl-errors=true', '--disk-cache=true'], {
     logLevel: 'debug',
-  }], // arguments passed to phantomjs-node directly, default is `[]`. For all opts, see https://github.com/amir20/phantomjs-node#phantom-object-api
+  }] // arguments passed to phantomjs-node directly, default is `[]`. For all opts, see https://github.com/amir20/phantomjs-node#phantom-object-api
 })
 
 // Automatically acquires a phantom instance and releases it back to the

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "node --harmony test/index.test.js && node --harmony test/maxuses.test.js",
+    "test": "node test/index.test.js && node test/maxuses.test.js",
     "build": "npm run clean && babel ./src --out-dir ./lib --copy-files",
     "clean": "rm -r ./lib/*",
     "lint": "eslint src/ test/"
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "blue-tape": "^1.0.0"
-},
+  },
   "dependencies": {
     "generic-pool": "^3.1.4",
     "phantom": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -1,59 +1,41 @@
 {
   "name": "phantom-pool",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Resource pool for Node.js PhantomJS",
-  "main": "./lib/index.js",
+  "main": "./src/index.js",
   "directories": {
     "test": "test"
   },
   "scripts": {
-    "test": "npm run test:fast",
+    "test": "node --harmony test/index.test.js && node --harmony test/maxuses.test.js",
     "build": "npm run clean && babel ./src --out-dir ./lib --copy-files",
-    "clean": "rimraf ./lib",
-    "lint": "eslint src/ test/",
-    "pretest": "npm run lint",
-    "test:fast": "babel-tape-runner test/*.test.js",
-    "test:watch": "nodemon --exec npm -- run --silent test:fast || true",
-    "semantic-release": "git push && npm test && semantic-release pre && npm run build && npm publish && semantic-release post"
+    "clean": "rm -r ./lib/*",
+    "lint": "eslint src/ test/"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/blockai/phantom-pool.git"
   },
-  "keywords": ["phantom", "phantomjs", "generic-pool", "pool", "pooling"],
+  "keywords": [
+    "phantom",
+    "phantomjs",
+    "generic-pool",
+    "pool",
+    "pooling"
+  ],
   "author": "Oli Lalonde <olalonde@gmail.com> (https://syskall.com/)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/blockai/phantom-pool/issues"
+    "url": "https://github.com/binded/phantom-pool"
   },
-  "homepage": "https://github.com/blockai/phantom-pool#readme",
+  "homepage": "https://github.com/binded/phantom-pool",
   "engines": {
     "node": ">=6"
   },
   "devDependencies": {
-    "babel-cli": "^6.18.0",
-    "babel-preset-blockai": "^1.1.0",
-    "babel-tape-runner": "^2.0.1",
-    "blue-tape": "^1.0.0",
-    "cz-conventional-changelog": "^1.2.0",
-    "eslint-config-blockai": "^1.0.3",
-    "nodemon": "^1.11.0",
-    "rimraf": "^2.5.4",
-    "semantic-release": "^6.3.2"
-  },
-  "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
-  },
-  "config": {
-    "commitizen": {
-      "path": "cz-conventional-changelog"
-    }
-  },
+    "blue-tape": "^1.0.0"
+},
   "dependencies": {
-    "debug": "^2.3.3",
     "generic-pool": "^3.1.4",
     "phantom": "^3.2.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-import phantom from 'phantom'
-import genericPool from 'generic-pool'
+const phantom = require('phantom')
+const genericPool = require('generic-pool')
 
 // import initDebug from 'debug'
 // const debug = initDebug('phantom-pool')
 
-export default ({
+module.exports = ({
   max = 10,
   // optional. if you set this, make sure to drain() (see step 3)
   min = 2,
@@ -33,14 +33,14 @@ export default ({
     min,
     idleTimeoutMillis,
     testOnBorrow,
-    ...otherConfig,
+    ...otherConfig
   }
   const pool = genericPool.createPool(factory, config)
   const genericAcquire = pool.acquire.bind(pool)
   pool.acquire = () => genericAcquire().then(r => {
     r.useCount += 1
     return r
-  })
+});
   pool.use = (fn) => {
     let resource
     return pool.acquire()
@@ -57,6 +57,5 @@ export default ({
         throw err
       })
   }
-
   return pool
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}]
-  }
-}

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
-import phantom from 'phantom'
-import http from 'http'
-import createPhantomPool from '../src'
+const phantom = require('phantom')
+const http = require('http')
+const createPhantomPool = require('../src')
 
 const startServer = () => new Promise((resolve, reject) => {
   const server = http.createServer((req, res) => {

--- a/test/example.js
+++ b/test/example.js
@@ -1,0 +1,38 @@
+const createPhantomPool = require('../src/index');
+
+// Returns a generic-pool instance
+const pool = createPhantomPool({
+  max: 10, // default
+  min: 2, // default
+  // how long a resource can stay idle in pool before being removed
+  idleTimeoutMillis: 30000, // default.
+  // maximum number of times an individual resource can be reused before being destroyed; set to 0 to disable
+  maxUses: 50, // default
+  // function to validate an instance prior to use; see https://github.com/coopernurse/node-pool#createpool
+  validator: () => Promise.resolve(true), // defaults to always resolving true
+  // validate resource before borrowing; required for `maxUses and `validator`
+  testOnBorrow: true, // default
+  // For all opts, see opts at https://github.com/coopernurse/node-pool#createpool
+  phantomArgs: [['--ignore-ssl-errors=true', '--disk-cache=true'], {
+    logLevel: 'debug'
+  }] // arguments passed to phantomjs-node directly, default is `[]`. For all opts, see https://github.com/amir20/phantomjs-node#phantom-object-api
+})
+
+// Automatically acquires a phantom instance and releases it back to the
+// pool when the function resolves or throws
+pool.use(async (instance) => {
+  const page = await instance.createPage()
+  const status = await page.open('http://google.com', { operation: 'GET' })
+  if (status !== 'success') {
+    throw new Error('cannot open google.com')
+  }
+  const content = await page.property('content')
+  return content
+}).then((content) => {
+  console.log(content)
+})
+
+// Destroying the pool:
+pool.drain().then(() => pool.clear())
+
+// For more API doc, see https://github.com/coopernurse/node-pool#generic-pool

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,5 @@
-import test from 'blue-tape'
-import createPool from '../src'
+const test = require('blue-tape')
+const createPool = require('../src')
 
 const getState = ({ size, available, pending, max, min }) => {
   const state = { size, available, pending, max, min }

--- a/test/maxuses.test.js
+++ b/test/maxuses.test.js
@@ -1,5 +1,5 @@
-import test from 'blue-tape'
-import createPool from '../src'
+const test = require('blue-tape')
+const createPool = require('../src')
 
 let phantomPool
 test('create pool with maxUses', async () => {


### PR DESCRIPTION
So, beforehand it appears that the package required babel to build, which was quite a problem because bable was ( I believe) failing to transpile exports default into module.exports and as such the package was unusable by non bable-users.

The package was also very heavy due to the various configurations for relatively unnecessary tooling considering its just a 100 line long script...

I removed a good part of the building dependencies from the package.json (see, all of them except phantom, the thread pool and the test runner if people wish to run tests).

I also fixed the README by making the example work and adding the command that runs it.

Hopefully this is fine with you, I understand that some tools may be used internally by your company and respect that, but this is a public facing package and its a real shame to have to struggle with a module that does such a simple job. 